### PR TITLE
Unit tests classificationbar

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "pre-release": "gulp --gulpfile release.js -t prerelease",
     "docs-app": "gulp docs-watch --pr development --appRoot ./apps/docs-app",
     "demo-app": "gulp --pr development --appRoot ./apps/demo-app",
-    "test": "node_modules/karma/bin/karma start src/test/karma.conf.js",
+    "test": "node node_modules/karma/bin/karma start src/test/karma.conf.js",
     "protractor": "node_modules/protractor/bin/protractor test/protractor.conf.js"
   },
   "dependencies": {

--- a/src/components/classificationbar/classificationbar.module.js
+++ b/src/components/classificationbar/classificationbar.module.js
@@ -105,7 +105,7 @@
    * @param {service} BltApi The ngBoltJS [BltApi](core.BltApi.html) service.
    *
    */
-  function bltClassificationbarController() {
+  function bltClassificationbarController( api ) {
 
     var ctrl = this;
     var classifications = {
@@ -134,12 +134,12 @@
     function init() {
       //confirm classification chosen and appropriately chosen
       if ( !ctrl.cls ) {
-        console.error("Missing required attribute: 'classification'");
+        api.error("Missing required attribute: 'classification'");
         return;
       } else {
         classification = classifications[ctrl.cls.toLowerCase()];
         if ( !classification ) {
-          console.error("Attribute 'classification' must be one of ['unclassified', 'confidential', 'secret', " +
+          api.error("Attribute 'classification' must be one of ['unclassified', 'confidential', 'secret', " +
             "'topsecret']. Current value: '" + ctrl.cls + "'. See: " + window.location + "/blt.classificationbar.bltClassificationBar.html");
           return;
         }
@@ -148,7 +148,7 @@
       //check for custom text entered in place of default text
       if ( angular.isDefined(ctrl.customText) ) {
         if ( ctrl.customText.indexOf(classification.display) < 0 ) {
-          console.error("Attribute 'custom-text' must contain at least one reference to standard classification " +
+          api.error("Attribute 'custom-text' must contain at least one reference to standard classification " +
             "display: " + classification.display + " See: " + window.location + "/blt.classificationbar.bltClassificationBar.html");
           return;
         }
@@ -159,7 +159,7 @@
         ctrl.classification.display = ctrl.customText;
       } else if ( ctrl.verbosity ) {
         if ( angular.isUndefined(verbosity[ctrl.verbosity]) ) {
-          console.warn("Attribute 'verbosity' contained invalid verbosity level: " + ctrl.verbosity + ". Valid values " +
+          api.warn("Attribute 'verbosity' contained invalid verbosity level: " + ctrl.verbosity + ". Valid values " +
             "are [0, 1, 2]. See: " + window.location + "/blt.classificationbar.bltClassificationBar.html");
         } else {
           ctrl.classification.display = verbosity[ctrl.verbosity] + ctrl.classification.display;
@@ -168,5 +168,5 @@
     }
   }
 
-  bltClassificationbarController.$inject = [];
+  bltClassificationbarController.$inject = ['BltApi'];
 })();

--- a/src/components/classificationbar/classificationbar.module.js
+++ b/src/components/classificationbar/classificationbar.module.js
@@ -105,7 +105,7 @@
    * @param {service} BltApi The ngBoltJS [BltApi](core.BltApi.html) service.
    *
    */
-  function bltClassificationbarController( api ) {
+  function bltClassificationbarController() {
 
     var ctrl = this;
     var classifications = {
@@ -134,12 +134,12 @@
     function init() {
       //confirm classification chosen and appropriately chosen
       if ( !ctrl.cls ) {
-        api.error("Missing required attribute: 'classification'");
+        console.error("Missing required attribute: 'classification'");
         return;
       } else {
         classification = classifications[ctrl.cls.toLowerCase()];
         if ( !classification ) {
-          api.error("Attribute 'classification' must be one of ['unclassified', 'confidential', 'secret', " +
+          console.error("Attribute 'classification' must be one of ['unclassified', 'confidential', 'secret', " +
             "'topsecret']. Current value: '" + ctrl.cls + "'. See: " + window.location + "/blt.classificationbar.bltClassificationBar.html");
           return;
         }
@@ -148,7 +148,7 @@
       //check for custom text entered in place of default text
       if ( angular.isDefined(ctrl.customText) ) {
         if ( ctrl.customText.indexOf(classification.display) < 0 ) {
-          api.error("Attribute 'custom-text' must contain at least one reference to standard classification " +
+          console.error("Attribute 'custom-text' must contain at least one reference to standard classification " +
             "display: " + classification.display + " See: " + window.location + "/blt.classificationbar.bltClassificationBar.html");
           return;
         }
@@ -159,7 +159,7 @@
         ctrl.classification.display = ctrl.customText;
       } else if ( ctrl.verbosity ) {
         if ( angular.isUndefined(verbosity[ctrl.verbosity]) ) {
-          api.warn("Attribute 'verbosity' contained invalid verbosity level: " + ctrl.verbosity + ". Valid values " +
+          console.warn("Attribute 'verbosity' contained invalid verbosity level: " + ctrl.verbosity + ". Valid values " +
             "are [0, 1, 2]. See: " + window.location + "/blt.classificationbar.bltClassificationBar.html");
         } else {
           ctrl.classification.display = verbosity[ctrl.verbosity] + ctrl.classification.display;
@@ -168,5 +168,5 @@
     }
   }
 
-  bltClassificationbarController.$inject = ['BltApi'];
+  bltClassificationbarController.$inject = [];
 })();

--- a/src/test/components/classificationbar.mocha.js
+++ b/src/test/components/classificationbar.mocha.js
@@ -2,7 +2,21 @@
 
 // Classificationbar Component Tests
 describe('classificationbar', function() {
+    // Define modules usually created during the gulp build process (need to load blt_core module).
+    beforeEach(function() {
+        angular.module('blt_config', []);
+        angular.module('blt_dataRoutes', []);
+        angular.module('blt_appProfile', []);
+        angular.module('blt_appViews', []);
+    });
+    
     // Load Module & Templates
+    
+    // blt_core module needs to be loaded for data-validate attribute to work (data-validate makes used of blt-validate directive). Provide BltApi with a config object.
+    beforeEach(module('blt_core', function($provide){
+        $provide.value('config', { defaultLogLevel: "warn", debug: true });
+    })); 
+
     beforeEach(module('blt_classificationbar'));
     beforeEach(module('templates'));
 
@@ -10,11 +24,13 @@ describe('classificationbar', function() {
     var outerScope;
     var innerScope;
     var compile;
+    var api;
 
     // Do This Before Each Test
-    beforeEach(inject(function($rootScope, $compile) {
+    beforeEach(inject(function($rootScope, $compile, BltApi) {
         outerScope = $rootScope;
         compile = $compile;
+        api = BltApi;
     }));
 
     //Test Group
@@ -33,12 +49,29 @@ describe('classificationbar', function() {
         });
 
         //Test
-        it('should not have classification', function() {
+        it('should log error if no classification specified', function() {
             element = angular.element('<blt-classificationbar></blt-classificationbar>');
             compile(element)(outerScope);
+            var mySpy = sinon.spy(api, 'error');
             outerScope.$digest();       
-            expect(element[0].children[0].children[0].innerText).to.equal("");
+            expect(sinon.assert.calledOnce(mySpy));
+            expect(sinon.assert.calledWith(mySpy,"Missing required attribute: 'classification'"));
+            mySpy.restore();
         });
+
+        //Test
+        it('should log error if classification is not unclassified, confidential, secrete, top-secret', function() {
+            var mySpy = sinon.spy(api,'error');
+            const value = "Not Supported";
+            element = angular.element('<blt-classificationbar data-classification="{{classification}}"></blt-classificationbar>');
+            outerScope.$apply(function() {
+                outerScope.classification = value;
+            });
+            compile(element)(outerScope);
+            outerScope.$digest();
+            expect(sinon.assert.calledOnce(mySpy));
+            mySpy.restore();
+        })
 
         //Test
         it("should have custom text", function() {
@@ -52,6 +85,19 @@ describe('classificationbar', function() {
             expect(element[0].children[0].children[0].innerText).to.equal(value);
         });
 
+        it('should log error if custom text does not reference classification', function() {
+            const value = "Custom Text";
+            var mySpy = sinon.spy(api,'error');
+            element = angular.element('<blt-classificationbar data-classification="unclassified" data-custom-text="{{text}}"></blt-classificationbar>');
+            outerScope.$apply(function() {
+                outerScope.text = value;
+            });
+            compile(element)(outerScope);
+            outerScope.$digest();
+            expect(sinon.assert.calledOnce(mySpy));
+            mySpy.restore();
+        });
+
         //Test
         it('should not have custom text', function() {
             element = angular.element('<blt-classificationbar data-classification="unclassified"></blt-classificationbar>');
@@ -63,7 +109,7 @@ describe('classificationbar', function() {
         //Nested Test Group
         describe("verbosity tests",function(){
             //Test
-            it("should have message corresponding to verbosity 2", function() {
+            it('should have message corresponding to verbosity 2', function() {
                 const value = 2;
                 element = angular.element('<blt-classificationbar data-classification="unclassified" data-verbosity="{{verbosity}}"></blt-classificationbar>');
                 outerScope.$apply(function() {
@@ -75,7 +121,7 @@ describe('classificationbar', function() {
             });
 
             //Test
-            it("should have message corresponding to verbosity 1", function() {
+            it('should have message corresponding to verbosity 1', function() {
                 const value = 1;
                 element = angular.element('<blt-classificationbar data-classification="unclassified" data-verbosity="{{verbosity}}"></blt-classificationbar>');
                 outerScope.$apply(function() {
@@ -87,7 +133,7 @@ describe('classificationbar', function() {
             });
             
             //Test  
-            it("should have message corresponding to verbosity 0 (default)", function() {
+            it('should have message corresponding to verbosity 0 (default)', function() {
                 const value = 0;
                 element = angular.element('<blt-classificationbar data-classification="unclassified" data-verbosity="{{verbosity}}"></blt-classificationbar>');
                 outerScope.$apply(function() {
@@ -97,6 +143,19 @@ describe('classificationbar', function() {
                 outerScope.$digest();   
                 expect(element[0].children[0].children[0].innerText).to.equal("UNCLASSIFIED");
             });
+
+            it('should log warning is verbosity is not 0, 1, or 2',function() {
+                var mySpy = sinon.spy(api,"warn");
+                const value = 3;
+                element = angular.element('<blt-classificationbar data-classification="unclassified" data-verbosity="{{verbosity}}"></blt-classificationbar>');
+                outerScope.$apply(function() {
+                    outerScope.verbosity = value;
+                });
+                compile(element)(outerScope);
+                outerScope.$digest();
+                expect(sinon.assert.calledOnce(mySpy));
+                mySpy.restore();
+            })
         });
     });
 });

--- a/src/test/components/classificationbar.mocha.js
+++ b/src/test/components/classificationbar.mocha.js
@@ -1,0 +1,102 @@
+'use strict';
+
+// Classificationbar Component Tests
+describe('classificationbar', function() {
+    // Load Module & Templates
+    beforeEach(module('blt_classificationbar'));
+    beforeEach(module('templates'));
+
+    var element;
+    var outerScope;
+    var innerScope;
+    var compile;
+
+    // Do This Before Each Test
+    beforeEach(inject(function($rootScope, $compile) {
+        outerScope = $rootScope;
+        compile = $compile;
+    }));
+
+    //Test Group
+    describe("will bind on create", function() {
+        //Test
+        it("should have classification", function() {
+            const value = "unclassified";
+            element = angular.element('<blt-classificationbar data-classification="{{classification}}"></blt-classificationbar>');
+            outerScope.$apply(function() {
+                outerScope.classification = value;
+            });
+            compile(element)(outerScope);
+            outerScope.$digest();
+            expect(element[0].children[0].classList.value.split(" ")).that.include("classification-bar-"+value);
+            expect(element[0].children[0].children[0].innerText).to.equal(value.toUpperCase());
+        });
+
+        //Test
+        it('should not have classification', function() {
+            element = angular.element('<blt-classificationbar></blt-classificationbar>');
+            compile(element)(outerScope);
+            outerScope.$digest();       
+            expect(element[0].children[0].children[0].innerText).to.equal("");
+        });
+
+        //Test
+        it("should have custom text", function() {
+            const value = "Custom Text For UNCLASSIFIED Content";
+            element = angular.element('<blt-classificationbar data-classification="unclassified" data-custom-text="{{text}}"></blt-classificationbar>');
+            outerScope.$apply(function() {
+                outerScope.text = value;
+            });
+            compile(element)(outerScope);
+            outerScope.$digest();
+            expect(element[0].children[0].children[0].innerText).to.equal(value);
+        });
+
+        //Test
+        it('should not have custom text', function() {
+            element = angular.element('<blt-classificationbar data-classification="unclassified"></blt-classificationbar>');
+            compile(element)(outerScope);
+            outerScope.$digest();       
+            expect(element[0].children[0].children[0].innerText).to.equal("UNCLASSIFIED");
+        });
+
+        //Nested Test Group
+        describe("verbosity tests",function(){
+            //Test
+            it("should have message corresponding to verbosity 2", function() {
+                const value = 2;
+                element = angular.element('<blt-classificationbar data-classification="unclassified" data-verbosity="{{verbosity}}"></blt-classificationbar>');
+                outerScope.$apply(function() {
+                    outerScope.verbosity = value;
+                });
+                compile(element)(outerScope);
+                outerScope.$digest();   
+                expect(element[0].children[0].children[0].innerText.split(":")[0]).to.equal("This page contains dynamic content - Highest Possible Classification");
+            });
+
+            //Test
+            it("should have message corresponding to verbosity 1", function() {
+                const value = 1;
+                element = angular.element('<blt-classificationbar data-classification="unclassified" data-verbosity="{{verbosity}}"></blt-classificationbar>');
+                outerScope.$apply(function() {
+                    outerScope.verbosity = value;
+                });
+                compile(element)(outerScope);
+                outerScope.$digest();
+                expect(element[0].children[0].children[0].innerText.split(":")[0]).to.equal("Highest Possible Classification");
+            });
+            
+            //Test  
+            it("should have message corresponding to verbosity 0 (default)", function() {
+                const value = 0;
+                element = angular.element('<blt-classificationbar data-classification="unclassified" data-verbosity="{{verbosity}}"></blt-classificationbar>');
+                outerScope.$apply(function() {
+                    outerScope.verbosity = value;
+                });
+                compile(element)(outerScope);
+                outerScope.$digest();   
+                expect(element[0].children[0].children[0].innerText).to.equal("UNCLASSIFIED");
+            });
+        });
+    });
+});

--- a/src/test/karma.conf.js
+++ b/src/test/karma.conf.js
@@ -6,6 +6,9 @@ module.exports = function(config) {
             '../node_modules/angular/angular.js',
             '../node_modules/angular-route/angular-route.js',
             '../node_modules/angular-mocks/angular-mocks.js',
+            '../node_modules/angular-truncate-2/src/angular-truncate-2.js',
+            '../node_modules/angular-animate/angular-animate.js',
+
 
             // Load Definitions
             // NOTE: These Must Load First


### PR DESCRIPTION
classificationbar.mocha.js 
- Defined modules usually created during the gulp build process (need to load blt_core module). 
- Load blt_core providing config object. 
- Rewrote unit tests to test that an error is logged when no data-classification attribute is applied, when custom text does not reference classification, and when data-classification is not a supported value. 
- Added unit test to test that a warning is logged when verbosity is not 1, 2, or 3. 

classificationbar.module.js 
- Added BltApi dependency.  karma.conf.js 
- Added angular-truncate and angular-animate dependencies.


