### PR TITLE
Unit tests modal

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "pre-release": "gulp --gulpfile release.js -t prerelease",
     "docs-app": "gulp docs-watch --pr development --appRoot ./apps/docs-app",
     "demo-app": "gulp --pr development --appRoot ./apps/demo-app",
-    "test": "node_modules/karma/bin/karma start src/test/karma.conf.js",
+    "test": "node node_modules/karma/bin/karma start src/test/karma.conf.js",
     "protractor": "node_modules/protractor/bin/protractor test/protractor.conf.js"
   },
   "dependencies": {

--- a/src/components/modal/modal.module.js
+++ b/src/components/modal/modal.module.js
@@ -510,7 +510,6 @@
      */
     function compile( tElem, tAttrs ) {
       var type = 'modal';
-
       if ( tAttrs.flip == "true"  ) {
         if ( tAttrs.size == 'full-screen' ) {
           console.error('You can not use the flip animation on full-screen modals.');

--- a/src/components/modal/modal.module.js
+++ b/src/components/modal/modal.module.js
@@ -511,7 +511,7 @@
     function compile( tElem, tAttrs ) {
       var type = 'modal';
 
-      if ( tAttrs.flip ) {
+      if ( tAttrs.flip == "true"  ) {
         if ( tAttrs.size == 'full-screen' ) {
           console.error('You can not use the flip animation on full-screen modals.');
         } else {

--- a/src/components/modal/modal.module.js
+++ b/src/components/modal/modal.module.js
@@ -478,8 +478,7 @@
    * </example>
    *
    */
-  function bltModal($timeout ) {
-    var subscriptions = {};
+  function bltModal( api, $timeout ) {
     var directive = {
       restrict: 'EA',
       scope: {
@@ -492,16 +491,6 @@
 
     return directive;
 
-    function subscribe( name, callback ) {
-      // Save subscription if it doesn't already exist
-      if ( !subscriptions[name] ) {
-        subscriptions[name] = [];
-      }
-      // Add callback to subscription
-      subscriptions[name].push(callback);
-      console.debug('Subscribed: ', name);
-    }
-
     /**
      * Compile function invoked by Angular during the compilation phase. The only thing we do here is register our
      * pre and post link functions.
@@ -512,11 +501,16 @@
       var type = 'modal';
       if ( tAttrs.flip == "true"  ) {
         if ( tAttrs.size == 'full-screen' ) {
-          console.error('You can not use the flip animation on full-screen modals.');
+          api.error('You can not use the flip animation on full-screen modals.');
         } else {
           tElem.addClass('modal-flip');
         }
       }
+
+      if(angular.isUndefined(tAttrs.id)) {
+        api.error('missing id attribute for blt-modal. See: '
+          + window.location + '/blt.modal.bltModal.html');
+      };
 
       return {
         pre: preLink,
@@ -562,7 +556,7 @@
         scope.flipping = false;
         scope.flipped = false;
 
-        subscribe(attrs.id, function( msg ) {
+        api.subscribe(attrs.id, function( msg ) {
           // Update scope  - wrap in $timeout to apply update to scope
           $timeout(function() {
             if ( msg == 'open' ) {
@@ -595,5 +589,5 @@
     }
   }
 
-  bltModal.$inject = ['$timeout'];
+  bltModal.$inject = ['BltApi', '$timeout'];
 })();

--- a/src/components/modal/modal.module.js
+++ b/src/components/modal/modal.module.js
@@ -478,7 +478,8 @@
    * </example>
    *
    */
-  function bltModal( api, $timeout ) {
+  function bltModal($timeout ) {
+    var subscriptions = {};
     var directive = {
       restrict: 'EA',
       scope: {
@@ -491,6 +492,16 @@
 
     return directive;
 
+    function subscribe( name, callback ) {
+      // Save subscription if it doesn't already exist
+      if ( !subscriptions[name] ) {
+        subscriptions[name] = [];
+      }
+      // Add callback to subscription
+      subscriptions[name].push(callback);
+      console.debug('Subscribed: ', name);
+    }
+
     /**
      * Compile function invoked by Angular during the compilation phase. The only thing we do here is register our
      * pre and post link functions.
@@ -502,7 +513,7 @@
 
       if ( tAttrs.flip ) {
         if ( tAttrs.size == 'full-screen' ) {
-          api.error('You can not use the flip animation on full-screen modals.');
+          console.error('You can not use the flip animation on full-screen modals.');
         } else {
           tElem.addClass('modal-flip');
         }
@@ -552,7 +563,7 @@
         scope.flipping = false;
         scope.flipped = false;
 
-        api.subscribe(attrs.id, function( msg ) {
+        subscribe(attrs.id, function( msg ) {
           // Update scope  - wrap in $timeout to apply update to scope
           $timeout(function() {
             if ( msg == 'open' ) {
@@ -585,5 +596,5 @@
     }
   }
 
-  bltModal.$inject = ['BltApi', '$timeout'];
+  bltModal.$inject = ['$timeout'];
 })();

--- a/src/test/components/modal.mocha.js
+++ b/src/test/components/modal.mocha.js
@@ -3,6 +3,20 @@
 //Modal Component Tests
 describe('modal', function() {
     // Load Module & Templates
+    
+    // Define modules usually created during the gulp build process (need to load blt_core module).
+    beforeEach(function() {
+        angular.module('blt_config', []);
+        angular.module('blt_dataRoutes', []);
+        angular.module('blt_appProfile', []);
+        angular.module('blt_appViews', []);
+    });
+    
+    // blt_core module needs to be loaded for data-validate attribute to work (data-validate makes used of blt-validate directive). Provide BltApi with a config object.
+    beforeEach(module('blt_core', function($provide){
+        $provide.value('config', { defaultLogLevel: "error", debug: true });
+    })); 
+
     beforeEach(module('blt_modal'));
     beforeEach(module('templates'));
 
@@ -10,14 +24,16 @@ describe('modal', function() {
     var outerScope;
     var innerScope;
     var compile;
+    var api;
 
     // Do This Before Each Test
-    beforeEach(inject(function($rootScope, $compile, $injector) {
-        element = angular.element('<blt-modal id="{{id}}" data-size="{{size}}" data-flip="{{flip}}"></blt-modal>');
+    beforeEach(inject(function($rootScope, $compile, BltApi) {
+        element = angular.element('<blt-modal data-id="myModal" data-size="{{size}}" data-flip="{{flip}}"></blt-modal>');
         outerScope = $rootScope;
         compile = $compile;
         compile(element)(outerScope);
         outerScope.$digest();
+        api = BltApi;
     }));
 
     // Test Group
@@ -25,19 +41,23 @@ describe('modal', function() {
         //Test
         it('should have an id', function() {
             const value = 123456;
+            element = angular.element('<blt-modal data-id="{{id}}"></blt-modal>');
             outerScope.$apply(function() {
                 outerScope.id = value;
             });
             compile(element)(outerScope);
             outerScope.$digest();
-            expect(element[0].attributes.getNamedItem('id').value).to.equal(value.toString());
+            expect(element[0].attributes.getNamedItem('data-id').value).to.equal(value.toString());
         });
 
-        it('should not have an id by default', function() {
+        it('should log error when modal does not have an id', function() {
+            var mySpy = sinon.spy(api,'error');
             element = angular.element('<blt-modal></blt-modal>');
             compile(element)(outerScope);
             outerScope.$digest();
             expect(element[0].attributes.getNamedItem('id')).to.equal(null);
+            expect(sinon.assert.calledOnce(mySpy));
+            mySpy.restore();
         });
 
         it('should have size', function() {
@@ -51,7 +71,7 @@ describe('modal', function() {
         });
 
         it('should have default size of small', function(){
-            element = angular.element('<blt-modal></blt-modal>');
+            element = angular.element('<blt-modal data-id="myModal"></blt-modal>');
             compile(element)(outerScope);
             outerScope.$digest();
             expect(element[0].children[0].classList.value.split(' ')).that.include('modal-small');
@@ -68,14 +88,14 @@ describe('modal', function() {
         });
 
         it('should not be a flipable modal by default', function() {
-            element = angular.element('<blt-modal></blt-modal>');
+            element = angular.element('<blt-modal data-id="myModal"></blt-modal>');
             compile(element)(outerScope);
             outerScope.$digest();
             expect(element[0].classList.value.split(' ')).that.does.not.include("modal-flip");
         });
 
         it('should log error if data-size="full-screen" and data-flip="true"',function() {
-            var mySpy = sinon.spy(console, "error");
+            var mySpy = sinon.spy(api, "error");
             outerScope.$apply(function() {
                 outerScope.flip = true;
                 outerScope.size = "full-screen";

--- a/src/test/components/modal.mocha.js
+++ b/src/test/components/modal.mocha.js
@@ -16,6 +16,8 @@ describe('modal', function() {
         element = angular.element('<blt-modal id="{{id}}" data-size="{{size}}" data-flip="{{flip}}"></blt-modal>');
         outerScope = $rootScope;
         compile = $compile;
+        compile(element)(outerScope);
+        outerScope.$digest();
     }));
 
     // Test Group
@@ -74,7 +76,10 @@ describe('modal', function() {
 
         it('should log error if data-size="full-screen" and data-flip="true"',function() {
             var mySpy = sinon.spy(console, "error");
-            element = angular.element('<blt-modal data-size="full-screen" data-flip="true"></blt-modal>');
+            outerScope.$apply(function() {
+                outerScope.flip = true;
+                outerScope.size = "full-screen";
+            });
             compile(element)(outerScope);
             outerScope.$digest();
             expect(sinon.assert.calledOnce(mySpy));

--- a/src/test/components/modal.mocha.js
+++ b/src/test/components/modal.mocha.js
@@ -1,0 +1,75 @@
+'use strict';
+
+//Modal Component Tests
+describe('modal', function() {
+    // Load Module & Templates
+    beforeEach(module('blt_modal'));
+    beforeEach(module('templates'));
+
+    var element;
+    var outerScope;
+    var innerScope;
+    var compile;
+
+    // Do This Before Each Test
+    beforeEach(inject(function($rootScope, $compile, $injector) {
+        element = angular.element('<blt-modal id="{{id}}" data-size="{{size}}" data-flip="{{flip}}"></blt-modal>');
+        outerScope = $rootScope;
+        compile = $compile;
+    }));
+
+    // Test Group
+    describe('will bind on create', function() {
+        //Test
+        it('should have an id', function() {
+            const value = 123456;
+            outerScope.$apply(function() {
+                outerScope.id = value;
+            });
+            compile(element)(outerScope);
+            outerScope.$digest();
+            expect(element[0].attributes.getNamedItem('id').value).to.equal(value.toString());
+        });
+
+        it('should not have an id by default', function() {
+            element = angular.element('<blt-modal></blt-modal>');
+            compile(element)(outerScope);
+            outerScope.$digest();
+            expect(element[0].attributes.getNamedItem('id')).to.equal(null);
+        });
+
+        it('should have size', function() {
+            const value = "medium";
+            outerScope.$apply(function() {
+                outerScope.size = value;
+            });
+            compile(element)(outerScope);
+            outerScope.$digest();
+            expect(element[0].children[0].classList.value.split(' ')).that.include("modal-medium");
+        });
+
+        it('should have default size of small', function(){
+            element = angular.element('<blt-modal></blt-modal>');
+            compile(element)(outerScope);
+            outerScope.$digest();
+            expect(element[0].children[0].classList.value.split(' ')).that.include('modal-small');
+        });
+
+        it('should be a flippable modal', function() {
+            outerScope.$apply(function() {
+                outerScope.flip = true;
+            });
+            compile(element)(outerScope);
+            outerScope.$digest();
+
+            expect(element[0].classList.value.split(' ')).that.include("modal-flip");
+        });
+
+        it('should not be a flipable modal by default', function() {
+            element = angular.element('<blt-modal></blt-modal>');
+            compile(element)(outerScope);
+            outerScope.$digest();
+            expect(element[0].classList.value.split(' ')).that.does.not.include("modal-flip");
+        });
+    });
+});

--- a/src/test/components/modal.mocha.js
+++ b/src/test/components/modal.mocha.js
@@ -71,5 +71,15 @@ describe('modal', function() {
             outerScope.$digest();
             expect(element[0].classList.value.split(' ')).that.does.not.include("modal-flip");
         });
+
+        it('should log error if data-size="full-screen" and data-flip="true"',function() {
+            var mySpy = sinon.spy(console, "error");
+            element = angular.element('<blt-modal data-size="full-screen" data-flip="true"></blt-modal>');
+            compile(element)(outerScope);
+            outerScope.$digest();
+            expect(sinon.assert.calledOnce(mySpy));
+            expect(sinon.assert.calledWith(mySpy, "You can not use the flip animation on full-screen modals."));
+            mySpy.restore();
+        });
     });
 });

--- a/src/test/karma.conf.js
+++ b/src/test/karma.conf.js
@@ -6,6 +6,8 @@ module.exports = function(config) {
             '../node_modules/angular/angular.js',
             '../node_modules/angular-route/angular-route.js',
             '../node_modules/angular-mocks/angular-mocks.js',
+            '../node_modules/angular-truncate-2/src/angular-truncate-2.js',
+            '../node_modules/angular-animate/angular-animate.js',
 
             // Load Definitions
             // NOTE: These Must Load First


### PR DESCRIPTION
modal.mocha.js
- Added BltApi dependency. 
- Removed variables/functions used instead of api functions. 
- Added error message that is displayed when a  modal does not have an id.  modal.mocha.js 
- Added beforeEach hook to define modules usually created during the gulp build process. 
- Added beforeEach hook to load blt_core.  

karma.conf.js 
- Added ngAnimate and ngTruncate dependencies

package.json
- Made "test" command runnable

modal.module.js
- Since tAttrs.flip is a string changed `if( tAttrs )` to `if( tAttrs.flip == "true")`
- Added error message if data-id attribute is not defined



