### PR TITLE
Unit tests panel

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "pre-release": "gulp --gulpfile release.js -t prerelease",
     "docs-app": "gulp docs-watch --pr development --appRoot ./apps/docs-app",
     "demo-app": "gulp --pr development --appRoot ./apps/demo-app",
-    "test": "node_modules/karma/bin/karma start src/test/karma.conf.js",
+    "test": "node node_modules/karma/bin/karma start src/test/karma.conf.js",
     "protractor": "node_modules/protractor/bin/protractor test/protractor.conf.js"
   },
   "dependencies": {

--- a/src/components/panel/panel.module.js
+++ b/src/components/panel/panel.module.js
@@ -7,7 +7,7 @@
    * @description ngBoltJS Panel component.
    * @since 1.0.0
    */
-  angular.module('blt_panel', [])
+  angular.module('blt_panel', ['blt_core'])
     .directive('bltPanel', bltPanel);
 
 
@@ -175,6 +175,7 @@
    *             </footer>
    *         </div>
    *     </blt-panel>
+   *     <button blt-open="menu" class="panel-btn-text">Open</button>
    *   </html>
    * </example>
    *
@@ -222,7 +223,7 @@
    * </example>
    *
    */
-  function bltPanel(api, $timeout ) {
+  function bltPanel( api, $timeout ) {
     var directive = {
       restrict: 'EA',
       scope: {
@@ -235,7 +236,7 @@
     };
 
     return directive;
-    
+
     /**
      * Compile function. Invoked by Angular. We use this function to register our pre and post link functions.
      * @returns {{pre: preLink, post: postLink}}
@@ -259,6 +260,11 @@
 
         scope.position = (scope.position) ? 'panel-' + scope.position : 'panel-right';
         scope.positionClass = scope.position;
+
+        if(!attrs.id) {
+          api.error('Missing id attribute for blt-panel. See: '
+           + window.location + '/blt.panel.bltPanel.html');
+        }
 
       }
 
@@ -303,5 +309,5 @@
     }
   }
 
-  bltPanel.$inject = ['BltApi','$timeout'];
+  bltPanel.$inject = ['BltApi', '$timeout'];
 })();

--- a/src/components/panel/panel.module.js
+++ b/src/components/panel/panel.module.js
@@ -7,7 +7,7 @@
    * @description ngBoltJS Panel component.
    * @since 1.0.0
    */
-  angular.module('blt_panel', ['blt_core'])
+  angular.module('blt_panel', [])
     .directive('bltPanel', bltPanel);
 
 
@@ -222,7 +222,8 @@
    * </example>
    *
    */
-  function bltPanel( api, $timeout ) {
+  function bltPanel($timeout ) {
+    var subscriptions = {};
     var directive = {
       restrict: 'EA',
       scope: {
@@ -236,6 +237,18 @@
 
     return directive;
 
+    function subscribe( name, callback ) {
+
+      // Save subscription if it doesn't already exist
+      if ( !subscriptions[name] ) {
+        subscriptions[name] = [];
+      }
+
+      // Add callback to subscription
+      subscriptions[name].push(callback);
+
+      console.debug('Subscribed: ', name);
+    }
     /**
      * Compile function. Invoked by Angular. We use this function to register our pre and post link functions.
      * @returns {{pre: preLink, post: postLink}}
@@ -257,7 +270,7 @@
       function preLink( scope, element, attrs ) {
         attrs.$set('blt-closable', type);
 
-        scope.position = 'panel-' + scope.position || 'panel-right';
+        scope.position = (scope.position) ? 'panel-' + scope.position : 'panel-right';
         scope.positionClass = scope.position;
 
       }
@@ -273,7 +286,7 @@
       function postLink( scope, element, attrs ) {
         scope.active = false;
 
-        api.subscribe(attrs.id, function( msg ) {
+        subscribe(attrs.id, function( msg ) {
           // Update scope  - wrap in $timeout to apply update to scope
           $timeout(function() {
             if ( msg == 'open' ) {
@@ -303,5 +316,5 @@
     }
   }
 
-  bltPanel.$inject = ['BltApi', '$timeout'];
+  bltPanel.$inject = ['$timeout'];
 })();

--- a/src/components/panel/panel.module.js
+++ b/src/components/panel/panel.module.js
@@ -222,8 +222,7 @@
    * </example>
    *
    */
-  function bltPanel($timeout ) {
-    var subscriptions = {};
+  function bltPanel(api, $timeout ) {
     var directive = {
       restrict: 'EA',
       scope: {
@@ -236,19 +235,7 @@
     };
 
     return directive;
-
-    function subscribe( name, callback ) {
-
-      // Save subscription if it doesn't already exist
-      if ( !subscriptions[name] ) {
-        subscriptions[name] = [];
-      }
-
-      // Add callback to subscription
-      subscriptions[name].push(callback);
-
-      console.debug('Subscribed: ', name);
-    }
+    
     /**
      * Compile function. Invoked by Angular. We use this function to register our pre and post link functions.
      * @returns {{pre: preLink, post: postLink}}
@@ -286,7 +273,7 @@
       function postLink( scope, element, attrs ) {
         scope.active = false;
 
-        subscribe(attrs.id, function( msg ) {
+        api.subscribe(attrs.id, function( msg ) {
           // Update scope  - wrap in $timeout to apply update to scope
           $timeout(function() {
             if ( msg == 'open' ) {
@@ -316,5 +303,5 @@
     }
   }
 
-  bltPanel.$inject = ['$timeout'];
+  bltPanel.$inject = ['BltApi','$timeout'];
 })();

--- a/src/components/view/view.module.js
+++ b/src/components/view/view.module.js
@@ -9,6 +9,6 @@
    * @since 2.0.0
    */
 
-  angular.module('blt_view', []);
+  angular.module('blt_view', ['blt_core', 'ngRoute']);
 
 })();

--- a/src/components/view/view.module.js
+++ b/src/components/view/view.module.js
@@ -9,6 +9,6 @@
    * @since 2.0.0
    */
 
-  angular.module('blt_view', ['blt_core', 'ngRoute']);
+  angular.module('blt_view', []);
 
 })();

--- a/src/test/components/panel.mocha.js
+++ b/src/test/components/panel.mocha.js
@@ -4,15 +4,18 @@
 describe('panel', function() {
     // Load Module & Templates
     beforeEach(module('blt_panel'));
+    beforeEach(module('blt_view'));
     beforeEach(module('templates'));
 
     var element;
     var outerScope;
     var innerScope;
     var compile;
+    var route;
+    var location;
 
     // Do This Before Each Test
-    beforeEach(inject(function($rootScope, $compile) {
+    beforeEach(inject(function($rootScope, $compile, $injector) {
         element = angular.element('<blt-panel id="{{id}}" data-position="{{position}}" data-fixed="{{fixed}}"></blt-panel>');
 
         outerScope = $rootScope;
@@ -20,6 +23,11 @@ describe('panel', function() {
         
         compile(element)(outerScope);
         outerScope.$digest();
+
+        route = $injector.get('ngRoute');
+        location = $injector.get('$location');
+        console.log(route);
+        console.log(location);
     }));
 
     describe("will bind on create", function() {
@@ -62,9 +70,9 @@ describe('panel', function() {
         
         // Test
         it('should be fixed', function(){
-            outerScope.$apply(function() {
-                outerScope.fixed = true;
-            });
+            element = angular.element('<blt-view><blt-panel data-position="top" data-fixed="true"><div panel-content>Panel Content</div></blt-panel></blt-view>');
+            compile(element)(outerScope);
+            outerScope.$digest();
             expect(element[0].attributes.getNamedItem("data-fixed").value).to.equal("true");
         });
         

--- a/src/test/components/panel.mocha.js
+++ b/src/test/components/panel.mocha.js
@@ -3,19 +3,24 @@
 //Panel Component Tests
 describe('panel', function() {
     // Load Module & Templates
+    beforeEach(module('ngRoute'));
+    beforeEach(module('blt_view', function($provide){
+        $provide.value( 'views', [{ "path": "/test", "route": { "template": '<blt-panel data-position="top" data-fixed="true"><div panel-content>Panel Content</div></blt-panel>'}, "animation": "fade"}]);
+    }));
     beforeEach(module('blt_panel'));
-    beforeEach(module('blt_view'));
     beforeEach(module('templates'));
 
     var element;
     var outerScope;
     var innerScope;
     var compile;
-    var route;
-    var location;
+    var factory;
+    var $route;
+    var $location;
+
 
     // Do This Before Each Test
-    beforeEach(inject(function($rootScope, $compile, $injector) {
+    beforeEach(inject(function($rootScope, $compile, viewFactory, _$route_, _$location_) {
         element = angular.element('<blt-panel id="{{id}}" data-position="{{position}}" data-fixed="{{fixed}}"></blt-panel>');
 
         outerScope = $rootScope;
@@ -23,11 +28,9 @@ describe('panel', function() {
         
         compile(element)(outerScope);
         outerScope.$digest();
-
-        route = $injector.get('ngRoute');
-        location = $injector.get('$location');
-        console.log(route);
-        console.log(location);
+        factory = viewFactory;
+        $route = _$route_;
+        $location = _$location_;
     }));
 
     describe("will bind on create", function() {
@@ -70,9 +73,17 @@ describe('panel', function() {
         
         // Test
         it('should be fixed', function(){
-            element = angular.element('<blt-view><blt-panel data-position="top" data-fixed="true"><div panel-content>Panel Content</div></blt-panel></blt-view>');
+            element = angular.element('<blt-view></blt-view>');
             compile(element)(outerScope);
             outerScope.$digest();
+
+            $location.path('/test');
+            outerScope.$apply();
+
+            console.log(element);
+            console.log($route);
+            console.log($location.$$path);
+
             expect(element[0].attributes.getNamedItem("data-fixed").value).to.equal("true");
         });
         

--- a/src/test/components/panel.mocha.js
+++ b/src/test/components/panel.mocha.js
@@ -1,0 +1,79 @@
+'use strict';
+
+//Panel Component Tests
+describe('panel', function() {
+    // Load Module & Templates
+    beforeEach(module('blt_panel'));
+    beforeEach(module('templates'));
+
+    var element;
+    var outerScope;
+    var innerScope;
+    var compile;
+
+    // Do This Before Each Test
+    beforeEach(inject(function($rootScope, $compile) {
+        element = angular.element('<blt-panel id="{{id}}" data-position="{{position}}" data-fixed="{{fixed}}"></blt-panel>');
+
+        outerScope = $rootScope;
+        compile = $compile;
+        
+        compile(element)(outerScope);
+        outerScope.$digest();
+    }));
+
+    describe("will bind on create", function() {
+        // Test    
+        it('should have an id', function() {
+            const value = 123456;
+            outerScope.$apply(function() {
+                outerScope.id = value;
+            });
+
+            expect(element[0].attributes.getNamedItem('id').value).to.equal(value.toString());
+        });
+            
+        // Test    
+        it('should not have an id by default', function() {
+            element = angular.element('<blt-panel></blt-panel>');
+            compile(element)(outerScope);
+            outerScope.$digest();
+            expect(element[0].attributes.getNamedItem("id")).to.equal(null);
+        });
+        
+        // Test
+        it('should have a position', function() {
+            const value = "left";
+            outerScope.$apply(function() {
+                outerScope.position = value;
+            });
+            compile(element)(outerScope);
+            outerScope.$digest();
+            expect(element[0].children[0].classList.value.split(" ")).that.include("panel-" + value);
+        });
+        
+        // Test
+        it('should have a position of right by default', function() {
+            element = angular.element('<blt-panel></blt-panel>');
+            compile(element)(outerScope);
+            outerScope.$digest();
+            expect(element[0].children[0].classList.value.split(" ")).that.include("panel-right");
+        });
+        
+        // Test
+        it('should be fixed', function(){
+            outerScope.$apply(function() {
+                outerScope.fixed = true;
+            });
+            expect(element[0].attributes.getNamedItem("data-fixed").value).to.equal("true");
+        });
+        
+        // Test
+        it('should not be fixed by default', function() {
+            element = angular.element('<blt-panel></blt-panel>');
+            compile(element)(outerScope);
+            outerScope.$digest();
+            expect(element[0].attributes.getNamedItem("data-fixed")).to.equal(null);
+        });
+    });
+});

--- a/src/test/karma.conf.js
+++ b/src/test/karma.conf.js
@@ -6,6 +6,9 @@ module.exports = function(config) {
             '../node_modules/angular/angular.js',
             '../node_modules/angular-route/angular-route.js',
             '../node_modules/angular-mocks/angular-mocks.js',
+            '../node_modules/angular-truncate-2/src/angular-truncate-2.js',
+            '../node_modules/angular-animate/angular-animate.js',
+
 
             // Load Definitions
             // NOTE: These Must Load First


### PR DESCRIPTION
panel.module.js
- (Re)Added blt_core dependency to blt_panel. 
- (Re)Added BltApi dependency to bltPanel. 
- Added button to the runnable example so the panel can be opened. 
- Added error message when a panel does not have an id.
- Corrected code used to set right as the default position.

panel.mocha.js 
- Define modules usually created during the gulp build process (need to load blt_core module). 
- Load blt_core providing config object. 
- Load blt_panel providing views array. 
- Removed mocked BltApi factory. 
- Rewrote unit test to make sure error is logged when a panel does not have an id.  

karma.conf.js 
- Added angular-truncate and angular-animate dependencies.

package.json
- Made `test` command runnable.


