### PR TITLE
Issue72 allow prelibs

### DIFF
--- a/gulp/libs-images.js
+++ b/gulp/libs-images.js
@@ -1,0 +1,35 @@
+var exception = require('./plugins/exception.js');
+var fs = require('fs');
+var path = require('path');
+var plumber = require('gulp-plumber');
+
+module.exports = function( gulp, config ) {
+  return function() {
+    // Define an array for font file paths.
+    var imageLibs = [];
+
+    // Add any other font file paths specified in 'build.json'.
+    for ( var i = 0; i < config.libraries.images.length; i++ ) {
+      var library = config.root + '/' + path.normalize(config.libraries.images[i]);
+      var directory = path.dirname(library);
+
+      if ( exists(directory) && imageLibs.indexOf(library) == -1 ) {
+        imageLibs.push(library);
+      }
+    }
+
+    function exists( directory ) {
+      try {
+        fs.statSync(directory);
+        return true;
+      } catch( e ) {
+        e.message = "ERROR: Directory " + e.path + " specified in ./config.libraries.fonts does not exist or is incorrect. \n" + e;
+        exception.error(e);
+      }
+    }
+
+    // Copy all font files to 'build' fonts directory.
+    return gulp.src(imageLibs)
+      .pipe(gulp.dest(config.buildDest + '/images'));
+  };
+};

--- a/gulp/libs-pre-js.js
+++ b/gulp/libs-pre-js.js
@@ -1,0 +1,36 @@
+var path = require('path');
+var fs = require('fs');
+var concat = require('gulp-concat');
+var gulpIf = require('gulp-if');
+var uglify = require('gulp-uglify');
+var exception = require('./plugins/exception.js');
+
+module.exports = function( gulp, config ) {
+  function exists( directory ) {
+    try {
+      fs.statSync(directory);
+      return true;
+    } catch( e ) {
+      e.message = "ERROR: Directory " + e.path + " specified in ./config.libraries.js does not exist or is incorrect. \n" + e;
+      exception.error(e);
+    }
+  }
+
+  return function() {
+    var preJsLibs = []
+    for ( var i = 0; i < config.libraries['pre-js'].length; i++ ) {
+      var library = config.root + '/' + path.normalize(config.libraries['pre-js'][i]);
+      var directory = path.dirname(library);
+
+      if ( exists(directory) && preJsLibs.indexOf(library) === -1 ) {
+        preJsLibs.push(library);
+      }
+    }
+
+    // Concat all external/vendor javascript files into one file and add to 'build' directory.
+    return gulp.src(preJsLibs)
+      .pipe(concat('pre-libs.js'))
+      .pipe(gulpIf(config.env == 'production' && !config.beautify, uglify()))
+      .pipe(gulp.dest(config.buildDest + '/libs'));
+  };
+};

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -48,6 +48,7 @@ var buildTasks = [
   'libs-css',
   'libs-fonts',
   'libs-pre-js',
+  'libs-images',
   'libs-js',
   'sass',
   'javascript'

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -47,6 +47,7 @@ var buildTasks = [
   'copy',
   'libs-css',
   'libs-fonts',
+  'libs-pre-js',
   'libs-js',
   'sass',
   'javascript'


### PR DESCRIPTION
In case this is helpful...
This is how we are currently monkey patching ng-bolt to allow our library dependencies to be loaded prior to the library and also to include assets from libraries.

Relates to:
https://github.com/ngbolt/ng-bolt/issues/72
